### PR TITLE
Add simple Flask-based TTS website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # TTS_free
-TTS  public site for free
+
+A simple web interface that converts user provided text to speech using `gTTS`.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Run the application:
+   ```bash
+   python app.py
+   ```
+
+3. Open `http://localhost:5000` in your browser and enter text to generate the audio file.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,19 @@
+from flask import Flask, request, render_template, send_file
+from gtts import gTTS
+import os
+
+app = Flask(__name__)
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        text = request.form.get('text', '')
+        if text:
+            tts = gTTS(text)
+            filepath = 'output.mp3'
+            tts.save(filepath)
+            return send_file(filepath, as_attachment=True)
+    return render_template('index.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+gTTS

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>TTS Converter</title>
+</head>
+<body>
+    <h1>Text to Speech</h1>
+    <form method="post">
+        <textarea name="text" rows="4" cols="50" placeholder="Enter text here"></textarea><br>
+        <button type="submit">Convert to Speech</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement `app.py` using Flask and gTTS
- create basic HTML form to submit text for conversion
- document how to install and run the site in README
- add `requirements.txt`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685e91fd791c8330b7d51db99f35314b