### PR TITLE
Add language and preview options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # TTS_free
 
 A simple web interface that converts user provided text to speech using `gTTS`.
+The page now lets you choose a language, preview the generated audio and
+download the result.
 
 ## Setup
 
@@ -14,4 +16,5 @@ A simple web interface that converts user provided text to speech using `gTTS`.
    python app.py
    ```
 
-3. Open `http://localhost:5000` in your browser and enter text to generate the audio file.
+3. Open `http://localhost:5000` in your browser and enter text to generate the
+   audio file.

--- a/app.py
+++ b/app.py
@@ -1,19 +1,29 @@
-from flask import Flask, request, render_template, send_file
+from flask import Flask, request, render_template, send_from_directory, url_for
 from gtts import gTTS
+from gtts.lang import tts_langs
 import os
+import uuid
 
 app = Flask(__name__)
 
 @app.route('/', methods=['GET', 'POST'])
 def index():
+    languages = tts_langs()
+    audio_url = None
     if request.method == 'POST':
         text = request.form.get('text', '')
+        lang = request.form.get('lang', 'en')
         if text:
-            tts = gTTS(text)
-            filepath = 'output.mp3'
+            tts = gTTS(text=text, lang=lang)
+            filename = f"{uuid.uuid4()}.mp3"
+            filepath = os.path.join('static', filename)
             tts.save(filepath)
-            return send_file(filepath, as_attachment=True)
-    return render_template('index.html')
+            audio_url = url_for('static', filename=filename)
+    return render_template('index.html', languages=languages, audio_url=audio_url)
+
+@app.route('/download/<filename>')
+def download_file(filename):
+    return send_from_directory('static', filename, as_attachment=True)
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,7 +7,21 @@
     <h1>Text to Speech</h1>
     <form method="post">
         <textarea name="text" rows="4" cols="50" placeholder="Enter text here"></textarea><br>
+        <label for="lang">Language:</label>
+        <select name="lang">
+            {% for code, name in languages.items() %}
+            <option value="{{ code }}">{{ name }}</option>
+            {% endfor %}
+        </select><br>
         <button type="submit">Convert to Speech</button>
     </form>
+
+    {% if audio_url %}
+    <h2>Preview:</h2>
+    <audio controls>
+        <source src="{{ audio_url }}" type="audio/mpeg">
+    </audio>
+    <p><a href="{{ url_for('download_file', filename=audio_url.split('/')[-1]) }}">Download Audio</a></p>
+    {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- save audio files in a static folder and expose a download route
- allow language selection and show an audio preview on the page
- document new preview and download options

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685e97ab5e3083308391eef8e2bbb8aa