### PR TITLE
Add audio preview with language and voice options

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, render_template, send_file
+from flask import Flask, request, render_template
 from gtts import gTTS
 import os
 
@@ -6,14 +6,19 @@ app = Flask(__name__)
 
 @app.route('/', methods=['GET', 'POST'])
 def index():
+    audio_file = None
     if request.method == 'POST':
         text = request.form.get('text', '')
+        language = request.form.get('language', 'en')
+        voice = request.form.get('voice', 'com')
         if text:
-            tts = gTTS(text)
-            filepath = 'output.mp3'
+            tts = gTTS(text=text, lang=language, tld=voice)
+            if not os.path.exists('static'):
+                os.makedirs('static')
+            filepath = os.path.join('static', 'output.mp3')
             tts.save(filepath)
-            return send_file(filepath, as_attachment=True)
-    return render_template('index.html')
+            audio_file = filepath
+    return render_template('index.html', audio_file=audio_file)
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,8 +13,31 @@
             <div class="mb-3">
                 <textarea name="text" class="form-control" rows="4" placeholder="Enter text here"></textarea>
             </div>
+            <div class="mb-3">
+                <label class="form-label">Language</label>
+                <select name="language" class="form-select">
+                    <option value="en" selected>English</option>
+                    <option value="fr">French</option>
+                    <option value="de">German</option>
+                    <option value="es">Spanish</option>
+                </select>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Voice</label>
+                <select name="voice" class="form-select">
+                    <option value="com" selected>Default</option>
+                    <option value="co.uk">UK</option>
+                    <option value="com.au">Australia</option>
+                    <option value="co.in">India</option>
+                </select>
+            </div>
             <button type="submit" class="btn btn-primary">Convert to Speech</button>
         </form>
+        {% if audio_file %}
+        <div class="mt-4">
+            <audio controls src="/{{ audio_file }}"></audio>
+        </div>
+        {% endif %}
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow selecting language and accent (voice) in UI
- generate mp3 preview and play it in the page

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685ea0a579e88330adab89b3430c8156