### PR TITLE
Add more language options

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 A simple web interface that converts user provided text to speech using `pyttsx3`.
 The web page now uses [Bootstrap](https://getbootstrap.com/) for a cleaner UI.
 
-The interface now lets you choose the language (English, Spanish, French or German)
+The interface now lets you choose the language (English, Spanish, French, German,
+Gujarati, Hindi, Arabic, Chinese, Japanese, Korean, Russian, Italian,
+Portuguese or Dutch)
 and the gender of the voice (male or female).
 
 ## Setup
@@ -12,10 +14,13 @@ and the gender of the voice (male or female).
    ```bash
    pip install -r requirements.txt
    ```
-   On Linux, `pyttsx3` relies on an external speech engine. Install
-   [eSpeak](https://github.com/espeak-ng/espeak-ng) or `espeak-ng` through
-   your package manager if you encounter a `RuntimeError` about missing
-   eSpeak.
+On Linux, `pyttsx3` relies on an external speech engine. Install
+[eSpeak](https://github.com/espeak-ng/espeak-ng) or `espeak-ng` through
+your package manager if you encounter a `RuntimeError` similar to:
+
+```
+pyttsx3 could not find a speech engine. Install eSpeak or espeak-ng on your system.
+```
 
 2. Run the application:
    ```bash

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,6 +20,16 @@
                     <option value="es">Spanish</option>
                     <option value="fr">French</option>
                     <option value="de">German</option>
+                    <option value="gu">Gujarati</option>
+                    <option value="hi">Hindi</option>
+                    <option value="ar">Arabic</option>
+                    <option value="zh">Chinese</option>
+                    <option value="ja">Japanese</option>
+                    <option value="ko">Korean</option>
+                    <option value="ru">Russian</option>
+                    <option value="it">Italian</option>
+                    <option value="pt">Portuguese</option>
+                    <option value="nl">Dutch</option>
                 </select>
             </div>
             <div class="mb-3">


### PR DESCRIPTION
## Summary
- expand language dropdown with ten more languages
- clarify README setup instructions for installing eSpeak when pyttsx3 fails
- list all languages in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686256583590833087c9a9f13ace7467